### PR TITLE
Arch: Don't explicitly install dependencies

### DIFF
--- a/portmaster/install/linux.md
+++ b/portmaster/install/linux.md
@@ -226,19 +226,13 @@ For Arch users we provide a PKGBUILD file in the [portmaster-packaging](https://
 
 To install the Portmaster using the PKGBUILD, follow these steps:
 
-```
-# Install build-dependencies, you can remove them later:
-sudo pacman -S imagemagick # required to convert the Portmaster logo to different resolutions
-
-# Install runtime dependencies:
-sudo pacman -S libnetfilter_queue webkit2gtk
-
+```bash
 # Clone the repository
 git clone https://github.com/safing/portmaster-packaging
 
 # Enter the repo and build/install the package (it's under linux/)
 cd portmaster-packaging/linux
-makepkg -i
+makepkg -is
 
 # Start the Portmaster and enable autostart
 sudo systemctl daemon-reload


### PR DESCRIPTION
By explicitly installing dependencies before building, they are marked
as "explicitly installed package" (rather than "installed as a
dependency for another package").

This leaves the dependency behind in case portmaster is later uninstalled.
It also leaves the build dependency installed indefinitely, instead of
it showing up as no longer needed dependency.

By just using `makepkg -s`, makepkg will install missing [make]depens
(if any), and also install them marking them as being installed as dependencies.

This also means you don't have to copy-paste the dependencies into one
more place if they ever change.