### PR TITLE
Fix path to logs directory on Windows

### DIFF
--- a/portmaster/architecture/core-service/fundamentals/index.md
+++ b/portmaster/architecture/core-service/fundamentals/index.md
@@ -50,7 +50,7 @@ This is what logs could look like:
 
 {% include code_ref.html godoc_portbase="dataroot" github_portbase="utils/structure.go" %}
 
-The Portmaster Application keeps everything it needs in a single directory. On Windows, this is `%APPDATA%\Safing\Portmaster` and on Linux it is `/var/lib/portmaster`.
+The Portmaster Application keeps everything it needs in a single directory. On Windows, this is `%PROGRAMDATA%\Safing\Portmaster` and on Linux it is `/var/lib/portmaster`.
 
 The `dataroot` is not a module, but just a small utility that provides easy access to it. It uses the `DirStructure` utility to ensure that all the directories always have the correct file system permissions.
 


### PR DESCRIPTION
The documentation says that logs on Windows are located at `%APPDATA%\Safing\Portmaster`, but at least on Windows11 this is not true:
* `%APPDATA%\Safing\Portmaster` directory does not exist - `%APPDATA%\Portmaster` does
* Logs are actually located at `%PROGRAMDATA%\Safing\Portmaster`

![portmaster-dirs](https://user-images.githubusercontent.com/32642697/145714135-9b5a8cd7-1609-4ea9-be56-04b7617ba3f2.png)

<details>
<summary>Version 0.7.10</summary>

```
Portmaster
version 0.7.10

commit tags/v0.7.10-0-gbb3591a7aeb47d6ccc0182936c4a0523ccdd89e4
built with go1.15.8 (gc) windows/amd64
  using options main.go
  by user@docker
  on 06.12.2021

Licensed under the AGPLv3 license.
The source code is available here: https://github.com/safing/portmaster
```

</details>

<details>
<summary>Platform: Microsoft Windows 11 Pro 10.0.22000 Build 22000</summary>

```
System: Microsoft Windows 11 Pro windows (Standalone Workstation) 10.0.22000 Build 22000
Kernel: 10.0.22000 Build 22000 x86_64

```

</details>