### PR TITLE
Added documentation for Dinit

### DIFF
--- a/portmaster/install/linux.md
+++ b/portmaster/install/linux.md
@@ -366,6 +366,29 @@ sudo sv up portmaster
 
 Artix Linux users can find the [portmaster-runit](https://aur.archlinux.org/packages/portmaster-runit/) package in the AUR
 
+#### Start Portmaster Automatically with Dinit
+__6.__ Start it on boot (Runit)
+
+In order to get the Portmaster Core Service to automatically start when booting, you need to create a dinit service file at `/etc/dinit.d/portmaster`.
+The following service file works, but may need to be apdated to your distribution as they do not all ship the same services.
+```sh
+type = process
+command = /opt/safing/portmaster/portmaster-start --data /opt/safing/portmaster core 
+depends-on = NetworkManager
+pid-file=/opt/safing/portmaster/core-lock.pid
+restart = yes
+restart-delay = 10
+working-dir = /opt/safing/portmaster
+```
+By default Dinit ships an environment file located at `/etc/dinit/environment`, make sure it exists and that it exports the PATH environment viariable, otherwise Portmaster Core won't be able to find the `iptables` binary
+It may look like that this (but can be different):
+```
+PATH=/usr/bin
+```
+Finnally enable and start the Portmaster: `sudo dinitctl enable portmaster`
+
+Artix Linux users can find the [portmaster-dinit](https://aur.archlinux.org/packages/portmaster-dinit) package in the AUR
+
 ### Frequently Asked Questions
 
 You can find solutions to common problems in the [FAQ]({{ site.faq_url }})

--- a/portmaster/install/linux.md
+++ b/portmaster/install/linux.md
@@ -138,7 +138,7 @@ __6.__ Start it on boot
 
 In case you are not using `systemd` as your init system - you most likely know if that is the case - these guides contributed by the community will get you started:
 - [Runit](#start-portmaster-automatically-with-runit)
-
+- [Dinit](#start-portmaster-automatically-with-dinit)
 In order to get the Portmaster Core Service to automatically start when booting, you need to create a systemd service unit at `/etc/systemd/system/portmaster.service`.
 The following unit file works but excludes most of the security relevant settings. For a more restricted version [use this portmaster.service file](https://github.com/safing/portmaster-packaging/blob/master/linux/portmaster.service).
 


### PR DESCRIPTION
Added documentation for the dinit init system.

To my knowledge only 2 distributions ships it, being Artix and Chimera Linux, both of which ships different services, in most likely scenario you'll have Network Manager installed so I selected it as the dependency.